### PR TITLE
Rekognition のリージョンを us-east-1 に変更

### DIFF
--- a/src/detect_related_image/app.py
+++ b/src/detect_related_image/app.py
@@ -14,7 +14,7 @@ stage = os.environ['Stage']
 config_bucket = os.environ['ConfigBucket']
 config_key_name = os.environ['ConfigKeyName']
 
-rekognition_cli = boto3.client('rekognition')
+rekognition_cli = boto3.client('rekognition', region_name='us-east-1')
 
 source_img = None
 


### PR DESCRIPTION
東京リージョンより $0.3/1000 API Call 安いので、レイテンシを許容してコストを抑える方向の us-east-1 を利用するように変更した
https://aws.amazon.com/jp/rekognition/pricing/